### PR TITLE
Framework compatibility and strict mode in functional scope

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -14,7 +14,7 @@ page {
 	# TYPO3 6.2
 	inlineJS {
 		482 = TEXT
-		482.value = $(function() { $('form').dependency(); });
+		482.value = jQuery(function() { jQuery('form').dependency(); });
 	}
 	# TYPO3 7 and newer
 	jsInline < .inlineJS

--- a/Resources/Public/JavaScript/jquery.dependency.js
+++ b/Resources/Public/JavaScript/jquery.dependency.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * jQuery dependency plugin
  *
@@ -30,10 +28,27 @@
  */
 
 (function($) {
+	'use strict';
+	function resetField(fieldName) {
+	try {
+		var $field = jQuery('[name="'+fieldName+'"]');
+		if (jQuery.inArray($field.prop('type'), ['radio', 'checkbox']) > -1) {
+			$field.each(function() {
+				//jQuery(this).prop('checked', false).trigger('change');
+			});
+			$field.first().trigger('change');
+		} else if ($field.prop('tagName').toLowerCase() == 'select') {
+			//$field.children().removeAttr('selected').trigger('change');
+		} else {
+			$field.val('').trigger('change');
+		}
+	} catch(e) {}
+}
+	
 	
 	jQuery.fn.dependency = function() {
 			
-		var $dependentFields = $(this).find('[data-depends-on]');
+		var $dependentFields = jQuery(this).find('[data-depends-on]');
 		var dependentTriggers = {};
 		$dependentFields.each(function(index, field) {
 			dependentTriggers[$(field).data('depends-on').toLowerCase().replace(/^A-Za-z0-9\-_/g, '')] = true;
@@ -62,7 +77,7 @@
 									changedVal = Array();
 									invertResult = !$triggerFields.filter(':checked').length > 1;
 									$triggerFields.filter(':checked').each(function() {
-										changedVal.push($(this).val());
+										changedVal.push(jQuery(this).val());
 									});
 								}
 								break;
@@ -141,21 +156,3 @@
 	}
 	
 } (jQuery));
-	
-function resetField(fieldName) {
-	try {
-		var $field = jQuery('[name="'+fieldName+'"]');
-		if (jQuery.inArray($field.prop('type'), ['radio', 'checkbox']) > -1) {
-			$field.each(function() {
-				//jQuery(this).prop('checked', false).trigger('change');
-			});
-			$field.first().trigger('change');
-		} else if ($field.prop('tagName').toLowerCase() == 'select') {
-			//$field.children().removeAttr('selected').trigger('change');
-		} else {
-			$field.val('').trigger('change');
-		}
-	} catch(e) {}
-}
-
-


### PR DESCRIPTION
First of all there were some calls of $ instead of jQuery. For users using another library this could lead to errors. I replaced them by the more secure jQuery call.

Also I move the "use strict" definition into the on ready call because this shouldn't force all other extension libraries to declare variables with var if you merge all your included js files. So moved from global to function scope just for this js.
